### PR TITLE
 Fix GitHub Actions: Add missing 'packaging' dependency

### DIFF
--- a/.github/workflows/train-github-only.yml
+++ b/.github/workflows/train-github-only.yml
@@ -29,7 +29,7 @@ jobs:
       - name: "📦 Install Dependencies"
         run: |
           pip install --upgrade pip
-          pip install torch numpy pandas scikit-learn onnx skl2onnx
+          pip install torch numpy pandas scikit-learn onnx skl2onnx packaging
 
       - name: "📊 Generate Training Data"
         run: |


### PR DESCRIPTION
## Problem
The 24/7 learning pipeline was failing with:
`
ModuleNotFoundError: No module named 'packaging'
`

## Solution
- Added packaging to the pip install command in the GitHub Actions workflow
- This dependency is required by skl2onnx but wasn't explicitly installed

## Impact
 24/7 learning pipeline will now run successfully every 30 minutes
 AI models will be trained and distributed automatically
 No more workflow failures due to missing dependencies