### PR TITLE
 Fix GitHub Release: Invalid Tag Name Error

### DIFF
--- a/.github/workflows/train-github-only.yml
+++ b/.github/workflows/train-github-only.yml
@@ -210,8 +210,11 @@ jobs:
       - name: "📦 Package Models"
         run: |
           cd models
-          tar -czf ml-models-$(date +%Y%m%d-%H%M%S).tar.gz rl/ manifest.json
-          echo "MODEL_PACKAGE=$(ls ml-models-*.tar.gz)" >> $GITHUB_ENV
+          timestamp=$(date +%Y%m%d-%H%M%S)
+          tar -czf ml-models-${timestamp}.tar.gz rl/ manifest.json
+          echo "MODEL_PACKAGE=ml-models-${timestamp}.tar.gz" >> $GITHUB_ENV
+          echo "RELEASE_TAG=models-v${timestamp}" >> $GITHUB_ENV
+          echo "RELEASE_DATE=$(date +'%Y-%m-%d %H:%M')" >> $GITHUB_ENV
 
       - name: "🚀 Create GitHub Release"
         uses: actions/create-release@v1
@@ -219,12 +222,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: models-v$(date +%Y%m%d-%H%M%S)
-          release_name: "AI Models $(date +'%Y-%m-%d %H:%M')"
+          tag_name: ${{ env.RELEASE_TAG }}
+          release_name: "AI Models ${{ env.RELEASE_DATE }}"
           body: |
             🤖 **Automated ML/RL Model Release**
             
-            **Training Completed**: $(date)
+            **Training Completed**: ${{ env.RELEASE_DATE }}
             **Models Included**:
             - Meta Strategy Classifier (ONNX)
             - Execution Quality Predictor (ONNX)  


### PR DESCRIPTION
## Problem
The 24/7 learning pipeline was failing at the release creation step with:
`
Validation Failed: tag_name is not a valid tag
`

## Root Cause  
The workflow was using shell command substitution directly in YAML fields, which GitHub Actions doesn't evaluate properly.

## Solution
 **Proper Environment Variables**: Set timestamp in a shell step first  
 **Valid Tag Names**: Use GitHub Actions env syntax
 **Consistent Timestamps**: Same timestamp used for package and tag  

## Expected Result
 **GitHub Releases will be created successfully**  
 **AI models will be packaged and distributed**  
 **Complete 24/7 learning pipeline will work end-to-end**