### PR TITLE
 Fix TA-Lib dependency installation for 24/7 learning

### DIFF
--- a/.github/workflows/train-github-only.yml
+++ b/.github/workflows/train-github-only.yml
@@ -50,10 +50,24 @@ jobs:
           
       - name: "📦 Install Dependencies"
         run: |
+          # Install system dependencies for TA-Lib
+          sudo apt-get update
+          sudo apt-get install -y build-essential wget
+          
+          # Download and install TA-Lib C library
+          wget http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
+          tar -xzf ta-lib-0.4.0-src.tar.gz
+          cd ta-lib/
+          ./configure --prefix=/usr
+          make
+          sudo make install
+          cd ..
+          
+          # Install Python packages
           pip install --upgrade pip
           pip install torch numpy pandas scikit-learn onnx skl2onnx packaging pyarrow
           pip install gym stable-baselines3 tensorboard matplotlib seaborn
-          pip install ta-lib talib-binary  # Technical analysis features
+          pip install TA-Lib  # Technical analysis features
           pip install optuna hyperopt  # Hyperparameter optimization
           
       - name: "🔍 Test Dependencies"  


### PR DESCRIPTION
Fixes the dependency installation issue blocking continuous learning:

- Remove non-existent 	alib-binary package that was causing install failures
- Add proper TA-Lib C library installation with system dependencies  
- Install build tools and compile TA-Lib from source
- This resolves the error: 'ERROR: No matching distribution found for talib-binary'

The bot's 24/7 learning has been failing on this dependency error every 30 minutes. This fix will restore continuous autonomous learning operation.