### PR TITLE
 Fix GitHub Pages 404: Add missing index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TopstepX Trading Bot Dashboard</title>
+    <meta http-equiv="refresh" content="0; url=./wwwroot/dashboard.html">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #0a0e16;
+            color: #e0e6ed;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .loading {
+            text-align: center;
+        }
+        .spinner {
+            border: 4px solid #f3f3f3;
+            border-top: 4px solid #4CAF50;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            animation: spin 2s linear infinite;
+            margin: 0 auto 20px;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        a {
+            color: #4CAF50;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="loading">
+        <div class="spinner"></div>
+        <h2>🤖 Loading Trading Bot Dashboard...</h2>
+        <p>Redirecting to dashboard...</p>
+        <p><a href="./wwwroot/dashboard.html">Click here if not redirected automatically</a></p>
+    </div>
+    
+    <script>
+        // Backup redirect in case meta refresh doesn't work
+        setTimeout(() => {
+            window.location.href = './wwwroot/dashboard.html';
+        }, 1000);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
**Problem:** GitHub Pages shows 404 error because root URL requires index.html

**Solution:** 
-  Add index.html that redirects to wwwroot/dashboard.html
-  Includes loading spinner and fallback JavaScript
-  Resolves 'File not found' error for GitHub Pages

**Result:** Dashboard will be accessible at kevinsuero072897-collab.github.io/trading-bot-c-/